### PR TITLE
MATLAB R2018a an earlier workaround added for all

### DIFF
--- a/unit_tests_subsref.m
+++ b/unit_tests_subsref.m
@@ -149,7 +149,9 @@ a = zeros(5, 5, 5); a(:) = 0.1*1:0.1:0.1*numel(a); ...
 b = zeros(2, 3, 4); b(:) = 1:numel(b); ...
 a_dbl = double(a);
 a_unc = unc(a);
-if all(a_dbl(b) == double(a_unc(b)), 'all')
+% MATLAB R2018a an earlier workaround
+temp = a_dbl(b) == double(a_unc(b));
+if all(temp(:))
     fprintf('PASSED: same result.\n');
 else
     fprintf('FAILED!\n');


### PR DESCRIPTION
MATLAB R2018a an earlier workaround added for all without support for 'all' argument.
See https://ch.mathworks.com/help/matlab/ref/all.html